### PR TITLE
[vslib] Refresh queue pause status

### DIFF
--- a/vslib/inc/SwitchStateBase.h
+++ b/vslib/inc/SwitchStateBase.h
@@ -145,6 +145,9 @@ namespace saivs
             virtual sai_status_t refresh_macsec_sci_in_ingress_macsec_acl(
                     _In_ sai_object_id_t object_id);
 
+            virtual sai_status_t refresh_queue_pause_status(
+                    _In_ sai_object_id_t object_id);
+
         public:
 
             virtual sai_status_t warm_boot_initialize_objects();

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -2000,6 +2000,11 @@ sai_status_t SwitchStateBase::refresh_read_only(
         return refresh_macsec_sci_in_ingress_macsec_acl(object_id);
     }
 
+    if (meta->objecttype == SAI_OBJECT_TYPE_QUEUE && meta->attrid == SAI_QUEUE_ATTR_PAUSE_STATUS)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
     auto mmeta = m_meta.lock();
 
     if (mmeta)

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -1851,6 +1851,20 @@ sai_status_t SwitchStateBase::refresh_macsec_sci_in_ingress_macsec_acl(
     return SAI_STATUS_SUCCESS;
 }
 
+sai_status_t SwitchStateBase::refresh_queue_pause_status(
+        _In_ sai_object_id_t object_id)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    attr.id = SAI_QUEUE_ATTR_PAUSE_STATUS;
+    attr.value.booldata = false;
+
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_QUEUE, object_id, &attr));
+
+    return SAI_STATUS_SUCCESS;
+}
+
 // XXX extra work may be needed on GET api if N on list will be > then actual
 
 /*
@@ -2002,7 +2016,7 @@ sai_status_t SwitchStateBase::refresh_read_only(
 
     if (meta->objecttype == SAI_OBJECT_TYPE_QUEUE && meta->attrid == SAI_QUEUE_ATTR_PAUSE_STATUS)
     {
-        return SAI_STATUS_SUCCESS;
+        return refresh_queue_pause_status(object_id);
     }
 
     auto mmeta = m_meta.lock();

--- a/vslib/src/SwitchStateBase.cpp
+++ b/vslib/src/SwitchStateBase.cpp
@@ -1856,6 +1856,10 @@ sai_status_t SwitchStateBase::refresh_queue_pause_status(
 {
     SWSS_LOG_ENTER();
 
+    // To trigger fake PFC storm on fake Broadcom platform, PFC storm detection
+    // lua requires SAI_QUEUE_ATTR_PAUSE_STATUS field to be present in COUNTERS_DB.
+    // However, the actual value of the attribute does not matter in this regard,
+    // so a dummy one is assigned here.
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_PAUSE_STATUS;
     attr.value.booldata = false;


### PR DESCRIPTION
Fix the following error message, when setting PFC WD config on port in swss vs test development.

```
114470 Mar 27 11:48:56.959426 97dc8d648d1a WARNING #syncd: :- refresh_read_only: need to recalculate RO: SAI_QUEUE_ATTR_PAUSE_STATUS
114471 Mar 27 11:48:56.959444 97dc8d648d1a ERR #syncd: :- collectQueueAttrs: Failed to get attr of queue 0x15000000000168: -15
```

`SAI_QUEUE_ATTR_PAUSE_STATUS` is prevented from being set to `COUNTERS_DB` on fake broadcom platform. The absence of `SAI_QUEUE_ATTR_PAUSE_STATUS` will cause pfc detect lua to exist early, not being able to reach the point of faking PFC storm using `DEBUG_STORM` in vs test.

Needed by